### PR TITLE
BOMB-2333 Convert VTS exporter to STS exporter

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,5 +1,5 @@
 repository:
-    path: github.com/hnlq715/nginx-vts-exporter
+    path: github.com/nutmegdevelopment/nginx-sts-exporter
 build:
     flags: -a -tags netgo
     ldflags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM        quay.io/prometheus/busybox:latest
-MAINTAINER  Sophos <hnlq.sysu@gmail.com>
+MAINTAINER  Sophos <devops@nutmeg.com>
 
-COPY nginx-vts-exporter  /bin/nginx-vts-exporter
+COPY nginx-sts-exporter  /bin/nginx-sts-exporter
 COPY docker-entrypoint.sh /bin/docker-entrypoint.sh
 
 ENV NGINX_HOST "http://localhost"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM        quay.io/prometheus/busybox:latest
-MAINTAINER  Sophos <devops@nutmeg.com>
+MAINTAINER  Bomb Squad <devops@nutmeg.com>
 
 COPY nginx-sts-exporter  /bin/nginx-sts-exporter
 COPY docker-entrypoint.sh /bin/docker-entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ pkgs   = $(shell $(GO) list ./... | grep -v /vendor/)
 
 PREFIX                  ?= $(shell pwd)
 BIN_DIR                 ?= $(shell pwd)
-DOCKER_IMAGE_NAME       ?= nginx-vts-exporter
+DOCKER_IMAGE_NAME       ?= nginx-sts-exporter
 DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 TAG 					:= $(shell echo `if [ "$(TRAVIS_BRANCH)" = "master" ] || [ "$(TRAVIS_BRANCH)" = "" ] ; then echo "latest"; else echo $(TRAVIS_BRANCH) ; fi`)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nginx-vts-exporter
+# nginx-sts-exporter
 
 [![Build Status](https://travis-ci.org/hnlq715/nginx-vts-exporter.svg?branch=master)](https://travis-ci.org/hnlq715/nginx-vts-exporter)
 [![Docker Pulls](https://img.shields.io/docker/pulls/sophos/nginx-vts-exporter.svg)](https://hub.docker.com/r/sophos/nginx-vts-exporter)
@@ -6,7 +6,7 @@
 [![GitHub release](https://img.shields.io/github/release/hnlq715/nginx-vts-exporter.svg)](https://github.com/hnlq715/nginx-vts-exporter)
 [![Go Report Card](https://goreportcard.com/badge/github.com/hnlq715/nginx-vts-exporter)](https://goreportcard.com/report/github.com/hnlq715/nginx-vts-exporter)
 
-Simple server that scrapes Nginx [vts](https://github.com/vozlt/nginx-module-vts) stats and exports them via HTTP for Prometheus consumption
+Simple server that scrapes Nginx [sts](https://github.com/vozlt/nginx-module-vts) stats and exports them via HTTP for Prometheus consumption
 
 To support time related histogram metrics, please refer to [hnlq715/nginx-prometheus-metrics](https://github.com/hnlq715/nginx-prometheus-metrics) or [#43](https://github.com/hnlq715/nginx-vts-exporter/issues/43).
 
@@ -60,12 +60,12 @@ It can be used directly instead of having to build the image yourself.
 
 ### run binary
 ``` shell
-nohup /bin/nginx-vts-exporter -nginx.scrape_uri=http://localhost/status/format/json
+nohup /bin/nginx-sts-exporter -nginx.scrape_uri=http://localhost/status/format/json
 ```
 
 ### run docker
 ```
-docker run  -ti --rm --env NGINX_STATUS="http://localhost/status/format/json" sophos/nginx-vts-exporter
+docker run  -ti --rm --env NGINX_STATUS="http://localhost/status/format/json" sophos/nginx-sts-exporter
 ```
 
 ## Environment variables
@@ -83,7 +83,7 @@ METRICS_NS | nginx | Prometheus metrics Namespaces
 
 Documents about exposed Prometheus metrics.
 
-For details on the underlying metrics please see [nginx-module-vts](https://github.com/vozlt/nginx-module-vts#json-used-by-status)
+For details on the underlying metrics please see [nginx-module-sts](https://github.com/vozlt/nginx-module-sts#json-used-by-status)
 
 For grafana dashboard please see [nginx-vts-exporter dashboard](https://grafana.com/dashboards/2949)
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,7 +13,7 @@ METRICS_NS=${METRICS_NS:-$DEFAULT_METRICS_NS}
 #echo "[$0] - Metrics Address   --> [$METRICS_ADDR]"
 #echo "[$0] - Metrics Endpoint  --> [$METRICS_ENDPOINT]"
 #echo "[$0] - Metrics Namespace  --> [$METRICS_NS]"
-#echo "[$0] - Running metrics nginx-vts-exporter"
+#echo "[$0] - Running metrics nginx-sts-exporter"
 
-exec nginx-vts-exporter -nginx.scrape_uri=$NGINX_STATUS -telemetry.address $METRICS_ADDR -telemetry.endpoint $METRICS_ENDPOINT -metrics.namespace $METRICS_NS
+exec nginx-sts-exporter -nginx.scrape_uri=$NGINX_STATUS -telemetry.address $METRICS_ADDR -telemetry.endpoint $METRICS_ENDPOINT -metrics.namespace $METRICS_NS
 #fi

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hnlq715/nginx-vts-exporter
+module github.com/nutmegdevelopment/nginx-sts-exporter
 
 go 1.12
 

--- a/nginx_sts_exporter.go
+++ b/nginx_sts_exporter.go
@@ -17,7 +17,7 @@ import (
 	"github.com/prometheus/common/version"
 )
 
-type NginxVts struct {
+type NginxSts struct {
 	HostName     string `json:"hostName"`
 	NginxVersion string `json:"nginxVersion"`
 	LoadMsec     int64  `json:"loadMsec"`
@@ -31,8 +31,8 @@ type NginxVts struct {
 		Handled  uint64 `json:"handled"`
 		Requests uint64 `json:"requests"`
 	} `json:"connections"`
-	ServerZones   map[string]Server              `json:"serverZones"`
-	UpstreamZones map[string][]Upstream          `json:"upstreamZones"`
+	ServerZones   map[string]Server              `json:"streamServerZones"`
+	UpstreamZones map[string][]Upstream          `json:"streamUpstreamZones"`
 	FilterZones   map[string]map[string]Upstream `json:"filterZones"`
 	CacheZones    map[string]Cache               `json:"cacheZones"`
 }
@@ -41,7 +41,7 @@ type Server struct {
 	RequestCounter uint64 `json:"requestCounter"`
 	InBytes        uint64 `json:"inBytes"`
 	OutBytes       uint64 `json:"outBytes"`
-	RequestMsec    uint64 `json:"requestMsec"`
+	SessionMsec    uint64 `json:"sessionMsec"`
 	Responses      struct {
 		OneXx       uint64 `json:"1xx"`
 		TwoXx       uint64 `json:"2xx"`
@@ -90,8 +90,7 @@ type Upstream struct {
 		FourXx  uint64 `json:"4xx"`
 		FiveXx  uint64 `json:"5xx"`
 	} `json:"responses"`
-	ResponseMsec uint64 `json:"responseMsec"`
-	RequestMsec  uint64 `json:"requestMsec"`
+	SessionMsec  uint64 `json:"uSessionMsec"`
 	Weight       uint64 `json:"weight"`
 	MaxFails     uint64 `json:"maxFails"`
 	FailTimeout  uint64 `json:"failTimeout"`
@@ -234,28 +233,28 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	var nginxVtx NginxVts
-	err = json.Unmarshal(data, &nginxVtx)
+	var nginxStx NginxSts
+	err = json.Unmarshal(data, &nginxStx)
 	if err != nil {
 		log.Println("json.Unmarshal failed", err)
 		return
 	}
 
 	// info
-	uptime := (nginxVtx.NowMsec - nginxVtx.LoadMsec) / 1000
-	ch <- prometheus.MustNewConstMetric(e.infoMetric, prometheus.GaugeValue, float64(uptime), nginxVtx.HostName, nginxVtx.NginxVersion)
+	uptime := (nginxStx.NowMsec - nginxStx.LoadMsec) / 1000
+	ch <- prometheus.MustNewConstMetric(e.infoMetric, prometheus.GaugeValue, float64(uptime), nginxStx.HostName, nginxStx.NginxVersion)
 
 	// connections
-	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxVtx.Connections.Active), "active")
-	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxVtx.Connections.Reading), "reading")
-	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxVtx.Connections.Waiting), "waiting")
-	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxVtx.Connections.Writing), "writing")
-	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxVtx.Connections.Accepted), "accepted")
-	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxVtx.Connections.Handled), "handled")
-	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxVtx.Connections.Requests), "requests")
+	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxStx.Connections.Active), "active")
+	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxStx.Connections.Reading), "reading")
+	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxStx.Connections.Waiting), "waiting")
+	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxStx.Connections.Writing), "writing")
+	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxStx.Connections.Accepted), "accepted")
+	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxStx.Connections.Handled), "handled")
+	ch <- prometheus.MustNewConstMetric(e.serverMetrics["connections"], prometheus.GaugeValue, float64(nginxStx.Connections.Requests), "requests")
 
 	// ServerZones
-	for host, s := range nginxVtx.ServerZones {
+	for host, s := range nginxStx.ServerZones {
 		ch <- prometheus.MustNewConstMetric(e.serverMetrics["requests"], prometheus.CounterValue, float64(s.RequestCounter), host, "total")
 		ch <- prometheus.MustNewConstMetric(e.serverMetrics["requests"], prometheus.CounterValue, float64(s.Responses.OneXx), host, "1xx")
 		ch <- prometheus.MustNewConstMetric(e.serverMetrics["requests"], prometheus.CounterValue, float64(s.Responses.TwoXx), host, "2xx")
@@ -275,15 +274,14 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(e.serverMetrics["bytes"], prometheus.CounterValue, float64(s.InBytes), host, "in")
 		ch <- prometheus.MustNewConstMetric(e.serverMetrics["bytes"], prometheus.CounterValue, float64(s.OutBytes), host, "out")
 
-		ch <- prometheus.MustNewConstMetric(e.serverMetrics["requestMsec"], prometheus.GaugeValue, float64(s.RequestMsec), host)
+		ch <- prometheus.MustNewConstMetric(e.serverMetrics["sessionMsec"], prometheus.GaugeValue, float64(s.SessionMsec), host)
 
 	}
 
 	// UpstreamZones
-	for name, upstreamList := range nginxVtx.UpstreamZones {
+	for name, upstreamList := range nginxStx.UpstreamZones {
 		for _, s := range upstreamList {
-			ch <- prometheus.MustNewConstMetric(e.upstreamMetrics["responseMsec"], prometheus.GaugeValue, float64(s.ResponseMsec), name, s.Server)
-			ch <- prometheus.MustNewConstMetric(e.upstreamMetrics["requestMsec"], prometheus.GaugeValue, float64(s.RequestMsec), name, s.Server)
+			ch <- prometheus.MustNewConstMetric(e.upstreamMetrics["sessionMsec"], prometheus.GaugeValue, float64(s.SessionMsec), name, s.Server)
 
 			ch <- prometheus.MustNewConstMetric(e.upstreamMetrics["requests"], prometheus.CounterValue, float64(s.RequestCounter), name, "total", s.Server)
 			ch <- prometheus.MustNewConstMetric(e.upstreamMetrics["requests"], prometheus.CounterValue, float64(s.Responses.OneXx), name, "1xx", s.Server)
@@ -298,10 +296,9 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	// FilterZones
-	for filter, values := range nginxVtx.FilterZones {
+	for filter, values := range nginxStx.FilterZones {
 		for name, stat := range values {
-			ch <- prometheus.MustNewConstMetric(e.filterMetrics["responseMsec"], prometheus.GaugeValue, float64(stat.ResponseMsec), filter, name)
-			ch <- prometheus.MustNewConstMetric(e.filterMetrics["requestMsec"], prometheus.GaugeValue, float64(stat.RequestMsec), filter, name)
+			ch <- prometheus.MustNewConstMetric(e.filterMetrics["sessionMsec"], prometheus.GaugeValue, float64(stat.SessionMsec), filter, name)
 			ch <- prometheus.MustNewConstMetric(e.filterMetrics["requests"], prometheus.CounterValue, float64(stat.RequestCounter), filter, name, "total")
 			ch <- prometheus.MustNewConstMetric(e.filterMetrics["requests"], prometheus.CounterValue, float64(stat.Responses.OneXx), filter, name, "1xx")
 			ch <- prometheus.MustNewConstMetric(e.filterMetrics["requests"], prometheus.CounterValue, float64(stat.Responses.TwoXx), filter, name, "2xx")
@@ -315,7 +312,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	// CacheZones
-	for zone, s := range nginxVtx.CacheZones {
+	for zone, s := range nginxStx.CacheZones {
 		ch <- prometheus.MustNewConstMetric(e.cacheMetrics["requests"], prometheus.CounterValue, float64(s.Responses.Bypass), zone, "bypass")
 		ch <- prometheus.MustNewConstMetric(e.cacheMetrics["requests"], prometheus.CounterValue, float64(s.Responses.Expired), zone, "expired")
 		ch <- prometheus.MustNewConstMetric(e.cacheMetrics["requests"], prometheus.CounterValue, float64(s.Responses.Hit), zone, "hit")
@@ -358,18 +355,18 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(version.NewCollector("nginx_vts_exporter"))
+	prometheus.MustRegister(version.NewCollector("nginx_sts_exporter"))
 }
 
 func main() {
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Fprintln(os.Stdout, version.Print("nginx_vts_exporter"))
+		fmt.Fprintln(os.Stdout, version.Print("nginx_sts_exporter"))
 		os.Exit(0)
 	}
 
-	log.Printf("Starting nginx_vts_exporter %s", version.Info())
+	log.Printf("Starting nginx_sts_exporter %s", version.Info())
 	log.Printf("Build context %s", version.BuildContext())
 
 	exporter := NewExporter(*nginxScrapeURI)

--- a/nginx_sts_exporter.go
+++ b/nginx_sts_exporter.go
@@ -183,19 +183,17 @@ func NewExporter(uri string) *Exporter {
 			"requests":    newServerMetric("requests", "requests counter", []string{"host", "code"}),
 			"bytes":       newServerMetric("bytes", "request/response bytes", []string{"host", "direction"}),
 			"cache":       newServerMetric("cache", "cache counter", []string{"host", "status"}),
-			"requestMsec": newServerMetric("requestMsec", "average of request processing times in milliseconds", []string{"host"}),
+			"sessionMsec": newServerMetric("sessionMsec", "average of session processing times in milliseconds", []string{"host"}),
 		},
 		upstreamMetrics: map[string]*prometheus.Desc{
 			"requests":     newUpstreamMetric("requests", "requests counter", []string{"upstream", "code", "backend"}),
 			"bytes":        newUpstreamMetric("bytes", "request/response bytes", []string{"upstream", "direction", "backend"}),
-			"responseMsec": newUpstreamMetric("responseMsec", "average of only upstream/backend response processing times in milliseconds", []string{"upstream", "backend"}),
-			"requestMsec":  newUpstreamMetric("requestMsec", "average of request processing times in milliseconds", []string{"upstream", "backend"}),
+			"sessionMsec":  newUpstreamMetric("sessionMsec", "average of session processing times in milliseconds", []string{"upstream", "backend"}),
 		},
 		filterMetrics: map[string]*prometheus.Desc{
 			"requests":     newFilterMetric("requests", "requests counter", []string{"filter", "filterName", "code"}),
 			"bytes":        newFilterMetric("bytes", "request/response bytes", []string{"filter", "filterName", "direction"}),
-			"responseMsec": newFilterMetric("responseMsec", "average of only upstream/backend response processing times in milliseconds", []string{"filter", "filterName"}),
-			"requestMsec":  newFilterMetric("requestMsec", "average of request processing times in milliseconds", []string{"filter", "filterName"}),
+			"sessionMsec":  newFilterMetric("sessionMsec", "average of session processing times in milliseconds", []string{"filter", "filterName"}),
 		},
 		cacheMetrics: map[string]*prometheus.Desc{
 			"requests": newCacheMetric("requests", "cache requests counter", []string{"zone", "status"}),


### PR DESCRIPTION
This is a fork of the Nginx VTS exporter
https://github.com/hnlq715/nginx-vts-exporter

This has been forked before to work with STS instead of VTS, but it has no commits for the last 2.5 years
https://github.com/marrotte/nginx-sts-exporter

Diff between the two
https://github.com/hnlq715/nginx-vts-exporter/compare/master...marrotte:master

Example output from running locally
```
# HELP nginx_server_bytes request/response bytes
# TYPE nginx_server_bytes counter
nginx_server_bytes{direction="in",host="*"} 0
nginx_server_bytes{direction="out",host="*"} 0
# HELP nginx_server_cache cache counter
# TYPE nginx_server_cache counter
nginx_server_cache{host="*",status="bypass"} 0
nginx_server_cache{host="*",status="expired"} 0
nginx_server_cache{host="*",status="hit"} 0
nginx_server_cache{host="*",status="miss"} 0
nginx_server_cache{host="*",status="revalidated"} 0
nginx_server_cache{host="*",status="scarce"} 0
nginx_server_cache{host="*",status="stale"} 0
nginx_server_cache{host="*",status="updating"} 0
# HELP nginx_server_connections nginx connections
# TYPE nginx_server_connections gauge
nginx_server_connections{status="accepted"} 15
nginx_server_connections{status="active"} 1
nginx_server_connections{status="handled"} 15
nginx_server_connections{status="reading"} 0
nginx_server_connections{status="requests"} 15
nginx_server_connections{status="waiting"} 0
nginx_server_connections{status="writing"} 1
# HELP nginx_server_info nginx info
# TYPE nginx_server_info gauge
nginx_server_info{hostName="1e832f1895cd",nginxVersion="1.17.4"} 3255
# HELP nginx_server_requests requests counter
# TYPE nginx_server_requests counter
nginx_server_requests{code="1xx",host="*"} 0
nginx_server_requests{code="2xx",host="*"} 0
nginx_server_requests{code="3xx",host="*"} 0
nginx_server_requests{code="4xx",host="*"} 0
nginx_server_requests{code="5xx",host="*"} 0
nginx_server_requests{code="total",host="*"} 0
# HELP nginx_server_sessionMsec average of session processing times in milliseconds
# TYPE nginx_server_sessionMsec gauge
nginx_server_sessionMsec{host="*"} 0
# HELP nginx_sts_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which nginx_sts_exporter was built.
# TYPE nginx_sts_exporter_build_info gauge
nginx_sts_exporter_build_info{branch="",goversion="go1.13",revision="",version=""} 1
# HELP nginx_upstream_bytes request/response bytes
# TYPE nginx_upstream_bytes counter
nginx_upstream_bytes{backend="172.22.40.230:443",direction="in",upstream="kubernetes-https"} 0
nginx_upstream_bytes{backend="172.22.40.230:443",direction="out",upstream="kubernetes-https"} 0
nginx_upstream_bytes{backend="172.22.40.230:80",direction="in",upstream="kubernetes-http"} 0
nginx_upstream_bytes{backend="172.22.40.230:80",direction="out",upstream="kubernetes-http"} 0
nginx_upstream_bytes{backend="172.22.41.134:443",direction="in",upstream="kubernetes-https"} 0
nginx_upstream_bytes{backend="172.22.41.134:443",direction="out",upstream="kubernetes-https"} 0
nginx_upstream_bytes{backend="172.22.41.134:80",direction="in",upstream="kubernetes-http"} 0
nginx_upstream_bytes{backend="172.22.41.134:80",direction="out",upstream="kubernetes-http"} 0
nginx_upstream_bytes{backend="172.22.42.116:443",direction="in",upstream="kubernetes-https"} 0
nginx_upstream_bytes{backend="172.22.42.116:443",direction="out",upstream="kubernetes-https"} 0
nginx_upstream_bytes{backend="172.22.42.116:80",direction="in",upstream="kubernetes-http"} 0
nginx_upstream_bytes{backend="172.22.42.116:80",direction="out",upstream="kubernetes-http"} 0
# HELP nginx_upstream_requests requests counter
# TYPE nginx_upstream_requests counter
nginx_upstream_requests{backend="172.22.40.230:443",code="1xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.40.230:443",code="2xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.40.230:443",code="3xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.40.230:443",code="4xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.40.230:443",code="5xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.40.230:443",code="total",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.40.230:80",code="1xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.40.230:80",code="2xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.40.230:80",code="3xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.40.230:80",code="4xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.40.230:80",code="5xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.40.230:80",code="total",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.41.134:443",code="1xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.41.134:443",code="2xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.41.134:443",code="3xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.41.134:443",code="4xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.41.134:443",code="5xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.41.134:443",code="total",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.41.134:80",code="1xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.41.134:80",code="2xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.41.134:80",code="3xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.41.134:80",code="4xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.41.134:80",code="5xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.41.134:80",code="total",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.42.116:443",code="1xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.42.116:443",code="2xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.42.116:443",code="3xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.42.116:443",code="4xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.42.116:443",code="5xx",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.42.116:443",code="total",upstream="kubernetes-https"} 0
nginx_upstream_requests{backend="172.22.42.116:80",code="1xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.42.116:80",code="2xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.42.116:80",code="3xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.42.116:80",code="4xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.42.116:80",code="5xx",upstream="kubernetes-http"} 0
nginx_upstream_requests{backend="172.22.42.116:80",code="total",upstream="kubernetes-http"} 0
# HELP nginx_upstream_sessionMsec average of session processing times in milliseconds
# TYPE nginx_upstream_sessionMsec gauge
nginx_upstream_sessionMsec{backend="172.22.40.230:443",upstream="kubernetes-https"} 0
nginx_upstream_sessionMsec{backend="172.22.40.230:80",upstream="kubernetes-http"} 0
nginx_upstream_sessionMsec{backend="172.22.41.134:443",upstream="kubernetes-https"} 0
nginx_upstream_sessionMsec{backend="172.22.41.134:80",upstream="kubernetes-http"} 0
nginx_upstream_sessionMsec{backend="172.22.42.116:443",upstream="kubernetes-https"} 0
nginx_upstream_sessionMsec{backend="172.22.42.116:80",upstream="kubernetes-http"} 0
```